### PR TITLE
fix(schemas) : Fix tiny YAML parse errors

### DIFF
--- a/gdcdictionary/schemas/analyte.yaml
+++ b/gdcdictionary/schemas/analyte.yaml
@@ -89,7 +89,8 @@ properties:
     description: "TODO: define, from BCR"
 # analyte parents
   portions:
-    $ref: "definitions.yaml#/to_one" #should this be to_one
+    #should this be to_one
+    $ref: "definitions.yaml#/to_one"
     description: >
       Indicates that the analyte is physically derived from the linked to
       portion via some process/protocol

--- a/gdcdictionary/schemas/definitions.yaml
+++ b/gdcdictionary/schemas/definitions.yaml
@@ -16,9 +16,7 @@ parent_uuids:
     uniqueItems: true
 
 foreign_key:
-  type:
-    object
-
+  type: object
   additionalProperties: false
   #Can either use 'id' which are GDC IDs (UUID) or 'aliases'
   #which are user defined IDs ("submitter IDs in the backend")

--- a/gdcdictionary/schemas/metaschema.yaml
+++ b/gdcdictionary/schemas/metaschema.yaml
@@ -4,7 +4,7 @@ id: "metaschema"
 title: "GDC JSON schema extension"
 
 allOf:
-  - "$ref": "http://json-schema.org/draft-04/schema#"
+  - $ref: "http://json-schema.org/draft-04/schema#"
 
 #GDC extensions
 required:

--- a/gdcdictionary/schemas/portion.yaml
+++ b/gdcdictionary/schemas/portion.yaml
@@ -69,7 +69,8 @@ properties:
     description: "TODO: define, from BCR"
 
   samples:
-    $ref: "definitions.yaml#/to_one" #should this be to_one
+    #should this be to_one
+    $ref: "definitions.yaml#/to_one" 
     description: >
       Indicates that the portion is physically derived from the linked to
       sample via some process/protocol

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -222,7 +222,8 @@ properties:
     type: boolean
     description: "TODO"
   cases:
-    $ref: "definitions.yaml#/to_one" #should this be to_one
+    #should this be to_one
+    $ref: "definitions.yaml#/to_one"
     description: >
       Indicates that the sample is physically derived from the subject
       of the linked to case via some process/protocol


### PR DESCRIPTION
Parsing all the schemas with YAML module in Perl, found several with small errors. Since [Ingy](https://metacpan.org/author/INGY) both invented YAML and wrote this parser, I thought I would take his word for it.
