### PR TITLE
fix(file_state): add process{ing,ed} states

### DIFF
--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -85,7 +85,7 @@ data_file_error_type:
         - file_size
         - file_format
         - md5sum
-        
+
 state:
     description: "states of all entities"
     default: submitted
@@ -126,6 +126,8 @@ file_state:
         - validating
         - validated
         - submitted
+        - processing
+        - processed
         - released
         - error
 


### PR DESCRIPTION
The [entity state definitions](https://wiki.oicr.on.ca/display/GDC/Entity+States) do not have a state specifying that the file is ready to be or being processed.  I believe this is necessary, as the term `submit` does not inherently mean `process` as well.  In the future I believe it will be very likely we will have to support the differentiation of these two commands.  Adding this property allows us to `submit` the file and later `process` the file, though at first I believe the submission UI could perform these two calls together.

r? @junjun-zhang @phuongmy @allisonheath @dmiller15 
