### PR TITLE
fix(backref): use correct entity name for backref

### DIFF
--- a/gdcdictionary/schemas/submitted_file.yaml
+++ b/gdcdictionary/schemas/submitted_file.yaml
@@ -22,7 +22,7 @@ systemProperties:
 
 links:
   - name: aliquots
-    backref: files
+    backref: submitted_files
     label: data_from
     target_type: aliquot
     multiplicity: many_to_many


### PR DESCRIPTION
Because of the way that datamodel do meta programming, backrefs have to be the format of `[entity_type]s` with exceptions [here](https://github.com/NCI-GDC/gdcdatamodel/blob/develop/gdcdatamodel/models/__init__.py#L62) which are for legacy projects. This will triggers key error when calling aliquot.files.
r? @millerjs @dmiller15 
