### PR TITLE
fix(portion): re-add shipped to center link

### DIFF
--- a/gdcdictionary/schemas/portion.yaml
+++ b/gdcdictionary/schemas/portion.yaml
@@ -34,6 +34,12 @@ links:
     target_type: sample
     multiplicity: many_to_one
     required: true
+  - name: centers
+    backref: portions
+    label: shipped_to
+    target_type: center
+    multiplicity: many_to_one
+    required: false
 
 # Portion properties
 # Currently there are many TCGA-specific fields in the DB. This is an attempt
@@ -78,6 +84,12 @@ properties:
     description: >
       Indicates that the portion is physically derived from the linked to
       sample via some process/protocol
+
+  centers:
+    # For shipped portions
+    $ref: "_definitions.yaml#/to_one"
+    description: "TODO: define"
+
   project_id:
     type: string
   created_datetime:


### PR DESCRIPTION
Re-add missing link from portion to center for shipped portions.
