### PR TITLE
Chore/schema constraints

### DIFF
--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -50,8 +50,10 @@ datetime:
 file_name:
     type: string
     description: "file name"
+
 file_size:
-    type: number
+    type: integer
+    minimum: 1
     description: "the size of the data file (object) in bytes"
 
 file_format:

--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -58,7 +58,8 @@ file_format:
     description: "the size of the data file (object) in bytes"
 md5sum:
     type: string
-    description: "the MD5 hash of the data file (object)"
+    pattern: "^[a-fA-F0-9]{32}$"
+    description: "the MD5 hash of the data"
 
 release_state:
     description: "Release statesd of an entity"

--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -53,9 +53,11 @@ file_name:
 file_size:
     type: number
     description: "the size of the data file (object) in bytes"
+
 file_format:
     type: string
-    description: "the size of the data file (object) in bytes"
+    description: "the format of the data file"
+
 md5sum:
     type: string
     pattern: "^[a-fA-F0-9]{32}$"

--- a/gdcdictionary/schemas/clinical.yaml
+++ b/gdcdictionary/schemas/clinical.yaml
@@ -94,7 +94,7 @@ properties:
       Numeric value to represent the year of an individual's initial pathologic
       diagnosis of cancer. CDE: 2896960.
   age_at_diagnosis:
-    type: number
+    type: integer
     minimum: 0
     description: >
       Age in days at which a condition or disease was first diagnosed.

--- a/gdcdictionary/schemas/clinical.yaml
+++ b/gdcdictionary/schemas/clinical.yaml
@@ -88,18 +88,21 @@ properties:
     description: >
       The survival state of the person registered on the protocol. CDE: 5.
   year_of_diagnosis:
-    type: number
+    type: integer
+    minimum: 0
     description: >
       Numeric value to represent the year of an individual's initial pathologic
       diagnosis of cancer. CDE: 2896960.
   age_at_diagnosis:
     type: number
+    minimum: 0
     description: >
       Age in days at which a condition or disease was first diagnosed.
       CDE: 3225640. TCGA has the age in years with CDE 2006657,
       this is converted by ceil(age*365.25) to get days.
   days_to_death:
     type: number
+    minimum: 0
     description: >
       Time interval from a person's date of death to the date of initial
       pathologic diagnosis, represented as a calculated number of days. CDE: 3165475.

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -89,12 +89,14 @@ properties:
   year_of_birth:
     term:
       $ref: "_terms.yaml#/year_of_birth"
-    type: number
+    type: integer
+    minimum: 0
 
   year_of_death:
     term:
       $ref: "_terms.yaml#/year_of_death"
-    type: number
+    type: integer
+    minimum: 0
 
   cases:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -69,21 +69,26 @@ properties:
     term:
       $ref: "_terms.yaml#/age_at_diagnosis"
     type: number
+    minimum: 1
+    maximum: 150
 
   days_to_birth:
     term:
       $ref: "_terms.yaml#/days_to_birth"
     type: number
+    maximum: 0
 
   days_to_death:
     term:
       $ref: "_terms.yaml#/days_to_death"
     type: number
+    minimum: 0
 
   days_to_last_follow_up:
     term:
       $ref: "_terms.yaml#/days_to_last_follow_up"
     type: number
+    minimum: 0
 
   vital_status:
     term:
@@ -153,6 +158,7 @@ properties:
     term:
       $ref: "_terms.yaml#/days_to_recurrence"
     type: number
+    minimum: 0
 
   last_known_disease_status:
     term:
@@ -169,6 +175,7 @@ properties:
     term:
       $ref: "_terms.yaml#/days_to_last_known_disease_status"
     type: number
+    minimum: 0
 
   cases:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -69,7 +69,7 @@ properties:
     term:
       $ref: "_terms.yaml#/age_at_diagnosis"
     type: number
-    minimum: 1
+    minimum: 0
     maximum: 150
 
   days_to_birth:

--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -53,11 +53,13 @@ properties:
     term:
       $ref: "_terms.yaml#/years_smoked"
     type: number
+    minimum: 0
 
   cigarettes_per_day:
     term:
       $ref: "_terms.yaml#/cigarettes_per_day"
     type: number
+    minimum: 0
 
   alcohol_history:
     term:

--- a/gdcdictionary/schemas/family_history.yaml
+++ b/gdcdictionary/schemas/family_history.yaml
@@ -74,6 +74,7 @@ properties:
   relationship_age_at_diagnosis:
     term: TBD # is there a dedicated term for this?
     type: number
+    minimum: 0
 
   relationship_primary_diagnosis:
     term:

--- a/gdcdictionary/schemas/file.yaml
+++ b/gdcdictionary/schemas/file.yaml
@@ -154,7 +154,8 @@ properties:
     type: string
     description: "TOREVIEW: the file (object) name"
   file_size:
-    type: number
+    type: integer
+    minimum: 1
     description: "the size file (object) in bytes"
   md5sum:
     type: string

--- a/gdcdictionary/schemas/file.yaml
+++ b/gdcdictionary/schemas/file.yaml
@@ -158,8 +158,7 @@ properties:
     minimum: 1
     description: "the size file (object) in bytes"
   md5sum:
-    type: string
-    description: "The MD5 hash of this file"
+    $ref: "_definitions.yaml#/md5sum"
   file_state:
     $ref: "_definitions.yaml#/file_state"
   state:

--- a/gdcdictionary/schemas/portion.yaml
+++ b/gdcdictionary/schemas/portion.yaml
@@ -64,12 +64,14 @@ properties:
       project. For TCGA this is bcrportionbarcode.
   weight:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   is_ffpe:
     type: boolean
     description: "TODO"
   creation_datetime:
     type: number
+    minimum: 0
     description: >
       TOREVIEW: The datetime of portion creation encoded as seconds from
       epoch. If no time is given, it is set to 00:00:00 of the date. Replaces

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -193,9 +193,11 @@ properties:
     description: "TODO"
   initial_weight:
     type: number
+    minimum: 0
     description: "TODO"
   current_weight:
     type: number
+    minimum: 0
     description: "TODO"
   freezing_method:
     type: string

--- a/gdcdictionary/schemas/slide.yaml
+++ b/gdcdictionary/schemas/slide.yaml
@@ -65,46 +65,57 @@ properties:
   percent_tumor_cells:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_tumor_nuclei:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_normal_cells:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_necrosis:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_stromal_cells:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_inflam_infiltration:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_lymphocyte_infiltration:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_monocyte_infiltration:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_granulocyte_infiltration:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_neutrophil_infiltration:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   percent_eosinophil_infiltration:
     type: number
     minimum: 0
+    maximum: 100
     description: "TODO: define, from BCR"
   portions:
     $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/slide.yaml
+++ b/gdcdictionary/schemas/slide.yaml
@@ -60,39 +60,51 @@ properties:
     description: "TODO: define, from BCR"
   number_proliferating_cells:
     type: integer
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_tumor_cells:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_tumor_nuclei:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_normal_cells:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_necrosis:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_stromal_cells:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_inflam_infiltration:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_lymphocyte_infiltration:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_monocyte_infiltration:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_granulocyte_infiltration:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_neutrophil_infiltration:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   percent_eosinophil_infiltration:
     type: number
+    minimum: 0
     description: "TODO: define, from BCR"
   portions:
     $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/treatment.yaml
+++ b/gdcdictionary/schemas/treatment.yaml
@@ -72,6 +72,7 @@ properties:
     term:
       $ref: "_terms.yaml#/days_to_treatment"
     type: number
+    minimum: 0
 
   diagnoses:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
This is a slew of small changes to the schema, primarily around imposing type and range constraints. I've kept the commits broken down so we can cherry pick certain ones into separate prs if desired. But mostly just want to get the conversation going.

Most of these add a `minimum` to `number` types, with notable exceptions being `age_at_diagnosis` and `days_to_birth` which have `maximum`s set. The CDE pages on `age_at_diagnosis` and `days_to_birth` specify that the former is in a range `[0,150]` and that the latter is explicitly negative. For everything else, it seems like the definition of the value range is more vague, but does not explicitly state negative values.

`year` fields were changed to be `integer` type, following the CDE description of a year value being a four-character field w/ 0 decimal places.

The other two major changes are in `md5sum` where I've added a string regex to match the `MD5` format, and restricted the `file_size` to be an `integer` type with minimum value of 1. This was discussed w/ @allisonheath and, unless there's a compelling reason not to, this should restrict us from accepting 0-byte files.

@NCI-GDC/ucdevs thoughts?
