### PR TITLE
fix(category): added "Raw Sequencing Data"

### DIFF
--- a/gdcdictionary/schemas/aligned_reads.yaml
+++ b/gdcdictionary/schemas/aligned_reads.yaml
@@ -59,7 +59,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/aligned_reads_index.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index.yaml
@@ -57,7 +57,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/aligned_reads_metric.yaml
+++ b/gdcdictionary/schemas/aligned_reads_metric.yaml
@@ -57,7 +57,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/analysis_metadata.yaml
+++ b/gdcdictionary/schemas/analysis_metadata.yaml
@@ -58,7 +58,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/experiment_metadata.yaml
+++ b/gdcdictionary/schemas/experiment_metadata.yaml
@@ -58,7 +58,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/read_group_metric.yaml
+++ b/gdcdictionary/schemas/read_group_metric.yaml
@@ -51,7 +51,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/run_metadata.yaml
+++ b/gdcdictionary/schemas/run_metadata.yaml
@@ -58,7 +58,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/submitted_aligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_aligned_reads.yaml
@@ -51,7 +51,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"

--- a/gdcdictionary/schemas/submitted_unaligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_unaligned_reads.yaml
@@ -50,7 +50,9 @@ properties:
   data_category:
     term:
       $ref: "_terms.yaml#/data_category"
-    enum: [ "Sequencing Data" ]
+    enum:
+      - Sequencing Data
+      - Raw Sequencing Data
   data_type:
     term:
       $ref: "_terms.yaml#/data_type"


### PR DESCRIPTION
Addresses PGDC-1988. This is for harmonized/active data, but added to enum instead of replacing in case minds change back. If confirmed as solution, should remove "Sequencing Data" from the enum in the future.

r? @dmiller15 @millerjs @philloooo 

cc @dankolbman 
