### PR TITLE
feat(supplements): add links to archive

### DIFF
--- a/gdcdictionary/schemas/biospecimen_supplement.yaml
+++ b/gdcdictionary/schemas/biospecimen_supplement.yaml
@@ -28,6 +28,12 @@ links:
     target_type: case
     multiplicity: many_to_one
     required: true
+  - name: archives
+    backref: biospecimen_supplements
+    label: member_of
+    target_type: archive
+    multiplicity: many_to_one
+    required: false
 
 required:
   - submitter_id
@@ -41,7 +47,7 @@ required:
 
 uniqueKeys:
   - [ id ]
-  - [ project_id, submitter_id ] 
+  - [ project_id, submitter_id ]
 
 properties:
   $ref: "_definitions.yaml#/data_file_properties"
@@ -61,4 +67,6 @@ properties:
     enum:
       - BCR XML
   cases:
+    $ref: "_definitions.yaml#/to_one"
+  archives:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/clinical_supplement.yaml
+++ b/gdcdictionary/schemas/clinical_supplement.yaml
@@ -28,6 +28,12 @@ links:
     target_type: case
     multiplicity: many_to_one
     required: true
+  - name: archives
+    backref: clinical_supplements
+    label: member_of
+    target_type: archive
+    multiplicity: many_to_one
+    required: false
 
 required:
   - submitter_id
@@ -61,4 +67,6 @@ properties:
     enum:
       - BCR XML
   cases:
+    $ref: "_definitions.yaml#/to_one"
+  archives:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
Because files that contained biospecimen and clinical xmls were linked to the archives that contained them
- add biopspecimen_supplement.archives -> archive
- add clinical_supplement.archives -> archive

r? @dmiller15 @allisonheath 
