### PR TITLE
feat(age): age_at_diagnosis now defined in days

### DIFF
--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -15,14 +15,13 @@ adapter_sequence: # TOREVIEW
 
 age_at_diagnosis:
   description: >
-    The numerical response indicating the age of a person, expressed in years,
-    when they were diagnosed with a disease or disorder.
+    Age at the time of diagnosis expressed in number of days since birth.
   termDef:
-    term: Person Diagnosis Age Value
-    source: caDSR
-    cde_id: 4828691
+    term: Patient Age at Diagnosis
+    source: caBIG
+    cde_id: 3225640
     cde_version: 1.0
-    term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4828691&version=1.0"
+    term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3225640&version=1.0"
 
 alcohol_history:
   description: >

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -32,7 +32,6 @@ links:
 
 required:
   - age_at_diagnosis
-  - days_to_birth
   - days_to_last_follow_up
   - vital_status
   - primary_diagnosis


### PR DESCRIPTION
days_to_birth no longer required

This is something we discussed last week. I've changed the time definition of age_at_diagnosis from years to days. This change effectively merges age_at_diagnosis and days_to_birth so I've also unrequired days_to_birth. If this is still our desired direction let me know.
@allisonheath @millerjs @philloooo 
