### PR TITLE
fix(read_group_qc): to read_group multiplicity

### DIFF
--- a/gdcdictionary/schemas/read_group_qc.yaml
+++ b/gdcdictionary/schemas/read_group_qc.yaml
@@ -4,7 +4,7 @@ id: "read_group_qc"
 title: Read Group QC
 type: object
 namespace: http://gdc.nci.nih.gov
-category: notation 
+category: notation
 project: '*'
 program: '*'
 description: "GDC QC run metadata."
@@ -37,7 +37,7 @@ links:
   - name: read_groups
     label: generated_from
     target_type: read_group
-    multiplicity: one_to_one
+    multiplicity: many_to_one
     required: true
     backref: read_group_qcs
 
@@ -60,7 +60,7 @@ required:
   - overrepresented_sequences
   - adapter_content
   - kmer_content
-  - read_groups  
+  - read_groups
 
 uniqueKeys:
   - [ id ]


### PR DESCRIPTION
Currently the link from QC to Read Group is one to one. This PR updates it to be many to one.

r? @dmiller15 @allisonheath 
