### PR TITLE
DAT-234 feat(mirna): added miRBase version property

### DIFF
--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -345,6 +345,10 @@ md5sum: # TOREVIEW
     The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's
     digital fingerprint. 
 
+mirbase_version:
+  description: >
+    Version of miRBase used to run the miRNA Profiling Pipeline.
+
 morphology:
   description: >
     The third edition of the International Classification of Diseases for Oncology, published in 2000

--- a/gdcdictionary/schemas/mirna_expression_workflow.yaml
+++ b/gdcdictionary/schemas/mirna_expression_workflow.yaml
@@ -46,5 +46,10 @@ properties:
     term:
       $ref: "_terms.yaml#/workflow_type"
     enum: [ "BCGSC miRNA Profiling" ]
+  mirbase_version:
+    term:
+      $ref: "_terms.yaml#/mirbase_version"
+    enum:
+      - miRBase 21
   aligned_reads_files:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
r? @allisonheath 

Minor issue for the time being as all our runs are miRBase 21. Not sure if there's another way of doing this, but here it is.

https://jira.opensciencedatacloud.org/browse/DAT-234
