### PR TITLE
DAT-295 feat(properties): re-add primary_site and disease_type to case

### DIFF
--- a/gdcdictionary/examples/valid/case.json
+++ b/gdcdictionary/examples/valid/case.json
@@ -1,6 +1,8 @@
 {
     "type": "case",
     "submitter_id": "BLGSP-71-06-00019",
+    "primary_site": "Lung",
+    "disease_type": "Burkitt's Lymphoma",
     "projects": {
         "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
     }

--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -202,6 +202,16 @@ days_to_treatment:
     cde_version: null
     term_url: null
 
+disease_type: # TOREVIEW
+  description: > 
+    Full name for the project.
+  termDef:
+    term: Disease Type
+    source: null
+    cde_id: null
+    cde_version: null
+    term_url: null
+
 encoding: # TOREVIEW
   description: >
     Version of ASCII encoding of quality values found in the file. 
@@ -445,6 +455,16 @@ primary_diagnosis:
     cde_id: 3081934
     cde_version: 3.0
     term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3081934&version=3.0" 
+
+primary_site:
+  description: >
+    Primary site for the project.
+  termDef:
+    term: Primary Site
+    source: null
+    cde_id: null
+    cde_version: null
+    term_url: null
 
 prior_malignancy:
   description: >

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -37,6 +37,8 @@ links:
 
 required:
   - submitter_id
+  - disease_type
+  - primary_site
   - projects
 
 uniqueKeys:
@@ -56,6 +58,14 @@ properties:
     type:
       - string
       - "null"
+  disease_type:
+    term:
+      $ref: "_terms.yaml#/disease_type"
+    type: string
+  primary_site:
+    term:
+      $ref: "_terms.yaml#/primary_site"
+    type: string
   projects:
     $ref: "_definitions.yaml#/to_one"
   tissue_source_sites:


### PR DESCRIPTION
Branching from a11f9e612cf63af5d4bd0e4041c8c3141f9c5e5b and cherry picking https://github.com/NCI-GDC/gdcdictionary/pull/175 to recreate history for https://github.com/NCI-GDC/esbuild/pull/129