### PR TITLE
Revert breaking changes for data release 5

### DIFF
--- a/gdcdictionary/examples/valid/analyte.json
+++ b/gdcdictionary/examples/valid/analyte.json
@@ -1,7 +1,7 @@
 {
     "type": "analyte",
     "submitter_id": "BLGSP-71-06-00019-99A-01D",
-    "28s_16s_ribosomal_rna_ratio": 1,
+    "ribosomal_rna_28s_16s_ratio": 1,
     "a260_a280_ratio": 1,
     "amount": 10.98,
     "analyte_quantity": 10,

--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -1,6 +1,6 @@
 id: _terms
 
-28s_16s_ribosomal_rna_ratio:
+ribosomal_rna_28s_16s_ratio:
   description: >
     The 28S/18S ribosomal RNA band ratio used to assess the quality of total RNA.
   termDef:
@@ -288,7 +288,7 @@ biomarker_name:
     term: Biomarker Name
     source: caDSR
     cde_id: 5473
-    cde_version: 11.0 
+    cde_version: 11.0
     term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5473&version=2.31"
 
 biomarker_result:
@@ -608,7 +608,7 @@ diagnosis_pathologically_confirmed:
     term_url: null
 
 disease_type: # TOREVIEW
-  description: > 
+  description: >
     Full name for the project.
   termDef:
     term: Disease Type
@@ -628,7 +628,7 @@ dlco_ref_predictive_percent:
     cde_version: 1.0
     term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2180255&version=1.0"
 
-encoding: 
+encoding:
   description: >
     Version of ASCII encoding of quality values found in the file.
   termDef:

--- a/gdcdictionary/schemas/analyte.yaml
+++ b/gdcdictionary/schemas/analyte.yaml
@@ -53,9 +53,9 @@ properties:
     description: >
       The legacy barcode used before prior to the use UUIDs, varies by
       project. For TCGA this is bcranalytebarcode.
-  28s_16s_ribosomal_rna_ratio:
+  ribosomal_rna_28s_16s_ratio:
     term:
-      $ref: "_terms.yaml#/28s_16s_ribosomal_rna_ratio"
+      $ref: "_terms.yaml#/ribosomal_rna_28s_16s_ratio"
     type: number
   a260_a280_ratio:
     term:

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -37,8 +37,6 @@ links:
 
 required:
   - submitter_id
-  - disease_type
-  - primary_site
   - projects
 
 uniqueKeys:

--- a/gdcdictionary/schemas/copy_number_segment.yaml
+++ b/gdcdictionary/schemas/copy_number_segment.yaml
@@ -29,13 +29,13 @@ links:
     subgroup:
       - name: copy_number_liftover_workflows
         backref: copy_number_segments
-        label: data_from
+        label: derived_from
         target_type: copy_number_liftover_workflow
         multiplicity: one_to_one
         required: false
       - name: genomic_profile_harmonization_workflows
         backref: copy_number_segments
-        label: data_from
+        label: derived_from
         target_type: genomic_profile_harmonization_workflow
         multiplicity: one_to_one
         required: false

--- a/gdcdictionary/schemas/metaschema.yaml
+++ b/gdcdictionary/schemas/metaschema.yaml
@@ -97,7 +97,7 @@ properties:
       - data_file
       - index_file
       - metadata_file
-      - notation 
+      - notation
       - qc_bundle
       - TBD
 
@@ -120,6 +120,14 @@ properties:
 
   system_properties:
     type: array
+
+  properties:
+    type: object
+    properties: {}
+    additionalProperties: false
+    patternProperties:
+      # Enforce that the property names do not start with numbers, etc
+      "^[_a-zA-Z][_a-zA-Z0-9]*$": {}
 
   links:
     title: "Define a link to other GDC entities"

--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -37,7 +37,6 @@ required:
   - platform
   - library_strategy
   - library_name
-  - instrument_model
   - is_paired_end
   - read_length
   - read_group_name


### PR DESCRIPTION
# Changes required for data release 5

##  Revert introduced required properties

- [X] verify that `read_group.instrument_model` was only addition
- [X] revert `read_group.instrument_model` in gdcdictionary#164

1. We cannot add a non-null constraint for existing fields without (a) verifying all the records have values or (b) populating them. Making instrument_model required for ReadGroup is a breaking schema change that necessitates an update to the data as well, else existing entries will be invalid.

2. The only implementation apparent here is a schema update, however this ticket addresses fields in the data that are not populated.

3. Because of (1), we need to (a) revert this change from develop or (b) populate all instrument_model fields. Due to scope, I am (a) reverting this change in gdcdictionary#190. I intend this ticket to serve as the ticket for applying both schema and data changes moving forward.

## Revert changed edge labels

- [X] revert `copy_number_segment` edge label

The edge label from `copy_number_segment` to `copy_number_liftover_workflows` was changed from `derived_from` to `data_from`.  Since this label differentiates edges between the same types of nodes, this change means deleting an edge and adding a new one with a different name.  As such I reverted this change.

## Revert breaking property names 

  - [x] rename s/28s_16s_ribosomal_rna_ratio/ribosomal_rna_28s_16s_ratio/g
  - [x] verify that no more property names don't match `^[_a-zA-Z][_a-zA-Z0-9]*$`

This change is required because we are injecting property names into certain places in the GDC.  Specifically, this breaks creation of fields for Graphene (for Submission GraphQL).

I've also updated the metaschema to validate against a sane property naming scheme to prevent this in the future and the tests will fail should a new property that does not match the regex `^[_a-zA-Z][_a-zA-Z0-9]*$` be added.

To note, `28s_16s_ribosomal_rna_ratio` was renamed to `ribosomal_rna_28s_16s_ratio` and not `` though the original BLGSP field is `bio: ratio_28s_18s [rna]` because the GDC already has properties that end with `_ratio` and therefore `ribosomal_rna_28s_16s_ratio` is more consistent.
