### PR TITLE
Change GDCDictionary init to bomb out with unicode in schemata files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
 before_script:
     - yes | python setup.py install
     - pip freeze
-script: "nosetests -v"
+script: "nosetests -sv"

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -64,7 +64,8 @@ class GDCDictionary(object):
         with open(name, 'r') as f:
             if name not in self.exclude:
                 try:
-                    ascii_file = f.read().encode("ascii")
+                    f.read().encode("ascii")
+                    f.seek(0)
                 except UnicodeDecodeError:
                     print "Error in file: {}".format(name)
                     raise

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -62,15 +62,13 @@ class GDCDictionary(object):
         # For DAT-1064 Bomb out hard if unicode is in a schema file
         # But allow unicode through the terms and definitions
         with open(name, 'r') as f:
-            if name in self.exclude:
-                return yaml.safe_load(f)
-            else:
+            if name not in self.exclude:
                 try:
                     ascii_file = f.read().encode("ascii")
                 except UnicodeDecodeError:
                     print "Error in file: {}".format(name)
                     raise
-                return yaml.safe_load(ascii_file)
+            return yaml.safe_load(f)
 
 
     def load_schemas_from_dir(self, directory):


### PR DESCRIPTION
(cherry picked from commit 6dad7862181135a6db5fc3e558f67f7c75adcc79)

Verified this breaks everything if there's a Unicode char in the schemata (But not in terms or definition files)