### PR TITLE
feat/TT-447: removed enum value from read_group.library_selection

### DIFF
--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -158,7 +158,6 @@ properties:
       - Hybrid_Selection
       - Hybrid Selection
       - PCR
-      - Affinity_Enrichment
       - Affinity Enrichment
       - Poly-T_Enrichment
       - Poly-T Enrichment


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-447

Removed "Affinity_Enrichment" from library_selection on node read_group.