### PR TITLE
TT-453: remove enum value from read_group.library_selection

### DIFF
--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -163,7 +163,6 @@ properties:
       - Poly-T_Enrichment
       - Poly-T Enrichment
       - Random
-      - RNA_Depletion
       - rRNA Depletion
       - miRNA Size Fractionation
       - Targeted Sequencing


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-453

Remove "RNA_Depletion" enum value from library_selection on node read_group