### PR TITLE
TT-451: remove enum value from read_group.library_selection

### DIFF
--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -155,7 +155,6 @@ properties:
     term:
       $ref: "_terms.yaml#/library_selection"
     enum:
-      - Hybrid_Selection
       - Hybrid Selection
       - PCR
       - Affinity_Enrichment


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-451

Remove "Hybrid_Selection" enum value from library_selection field on read_group node