### PR TITLE
TT-451: Removed enum value from read_groups.library_selection

### DIFF
--- a/gdcdictionary/examples/valid/read_group.json
+++ b/gdcdictionary/examples/valid/read_group.json
@@ -12,7 +12,7 @@
     "is_paired_end": true,
     "lane_number":4,
     "library_strategy": "WXS",
-    "library_selection": "Hybrid_Selection",
+    "library_selection": "Hybrid Selection",
     "library_name": "Solexa-34688",
     "multiplex_barcode":"AWDS342",
     "platform": "Illumina",

--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -155,7 +155,6 @@ properties:
     term:
       $ref: "_terms.yaml#/library_selection"
     enum:
-      - Hybrid_Selection
       - Hybrid Selection
       - PCR
       - Affinity_Enrichment


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-451

The enum value "Hybrid_Selection" was removed from library_selection on node read_group