### PR TITLE
feat(TT-383) : added new field to exposure node

### DIFF
--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -164,6 +164,26 @@ albumin:
     cde_version: 4.0
     term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=58274&version=4.0"
 
+alcohol_days_per_week:
+  description: >
+    Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  termDef:
+    term: Alcohol Consumption Weekly Days Usage Number
+    source: caDSR
+    cde_id: 3114013
+    cde_version: 1.0
+    term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=3114013&version=1.0"
+
+alcohol_drinks_per_day:
+  description: >
+    Numeric value used to describe the average number of alcoholic beverages  a person consumes per day.
+  termDef:
+    term: Person Daily Alcohol Consumption Count
+    source: caDSR
+    cde_id: 3124961
+    cde_version: 1.0
+    term_url: "https://cdebrowser.nci.nih.gov/cdebrowserClient/cdeBrowser.html#/search?publicId=3124961&version=1.0"
+
 alcohol_history:
   description: >
     A response to a question that asks whether the participant has consumed at least 12 drinks of

--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -130,6 +130,16 @@ properties:
       $ref: "_terms.yaml#/years_smoked"
     type: number
 
+  alcohol_days_per_week:
+    term:
+      $ref: "_terms.yaml#/alcohol_days_per_week"
+    type: number
+
+  alcohol_drinks_per_day:
+    term:
+      $ref: "_terms.yaml#/alcohol_drinks_per_day"
+    type: number
+
   cases:
     $ref: "_definitions.yaml#/to_one"
   project_id:


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-383

Second PR for this. We jumped the gun and merged to release/horton without signoff. Here's what was done to get it to this state.
```
gdcdictionary
g fetch #get all the references no objects updated, but now git status knows stuff
g merge-base release/horton origin/release/horton #I know there's a difference
 between my local release/horton and what happened on the origin (github)
g show 1119595d78e4b53c7d958beef9669735876fefd9 #merge-base returned this sha
 which indicates the most recent common ancestor between release/horton and origin/release/horton
g checkout release/horton
g log # Confirmed that my release/horton branch is pointing to the sha above
g push -f # update orgins reference to my version of release horton (will fail
 without f, because history is lost)
g status
# At this point release/horton is as it was
# Note I do not update my version of feat/TT-383-exposure-node! Git status at this
 

point says I'm behind
g checkout feat/TT-383-exposure-node
g fetch # paranoia
g log
g diff
# Looking at the log I think this would do better as a single commit
g rebase --interactive release/horton
# Squashed the underscore commit into the feature commit
g status # Diverged
g push -f # Force remote to match my local feat/TT-383 branch

# NOTE I have `g` aliased to `git`
# WARNING g push -f has the potential to overwrite remote history, and should not be used lightly
# especially if your config.push_default is not set to simple
```