### PR TITLE
Feat/TT-441 remove cns data type

### DIFF
--- a/gdcdictionary/schemas/copy_number_segment.yaml
+++ b/gdcdictionary/schemas/copy_number_segment.yaml
@@ -70,8 +70,6 @@ properties:
     enum:
       - Copy Number Segment
       - Masked Copy Number Segment
-      - Gene Level Copy Number
-      - Gene Level Copy Number Scores
   data_format:
     term:
       $ref: "_terms.yaml#/data_format"


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-441

Removed two enums "Gene Level Copy Number" and "Gene Level Copy Number Scores" from copy_number_segment.data_type.