### PR TITLE
TT-465: Two fields on project node are no longer required

### DIFF
--- a/gdcdictionary/schemas/project.yaml
+++ b/gdcdictionary/schemas/project.yaml
@@ -23,9 +23,7 @@ systemProperties:
 required:
   - code
   - name
-  - disease_type
   - state
-  - primary_site
   - programs
   - dbgap_accession_number
 


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-465

primary_site and disease_type fields were removed from the list of required fields on the project node

