### PR TITLE
TT-430: Remove OMF from clinical_supplement.data_format

### DIFF
--- a/gdcdictionary/schemas/clinical_supplement.yaml
+++ b/gdcdictionary/schemas/clinical_supplement.yaml
@@ -69,7 +69,6 @@ properties:
       - BCR XML
       - CDC JSON
       - FoundationOne XML
-      - OMF
       - XLSX
   cases:
     $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/TT-430

Remove "OMF" enum value from clinical_supplement.data_format