### PR TITLE
fix(test): potential error, non traversal of leaves

### DIFF
--- a/gdcdictionary/tests/schema_test.py
+++ b/gdcdictionary/tests/schema_test.py
@@ -15,7 +15,6 @@ class SchemaTest(BaseTest):
     def traverse_schema_with_conditional(self, root, conditional_func, test_func):
         if conditional_func(root):
             test_func(root)
-            return
 
         if isinstance(root, list):
             for child in root:


### PR DESCRIPTION
Potential edge case for additional tests. Don't return if the trigger condition is met, which basically means this wouldn't check children nodes in the schema. Not important for the enum test, but future tests may not expect it.

Passed tests locally.