### PR TITLE
fix(DAT-1370): fix typo in read_groups.target_capture_kit

### DIFF
--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -294,7 +294,7 @@ properties:
       - SeqCap EZ HGSC VCRome v2.1
       - SureSelect Human All Exon v3
       - SureSelect Human All Exon v5
-      - TruSeq Amplicon Cancer OncoPanel
+      - TruSeq Amplicon Cancer Panel
       - TruSeq Exome Enrichment - 62 Mb
       - TruSight Myeloid Sequencing Panel
       - Not Applicable


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/DAT-1370 

Fixed typo in read_group.target_capture_kit from "TruSeq Amplicon Cancer OncoPanel"  to "TruSeq Amplicon Cancer Panel"