### PR TITLE
feat(dictionary): Allow submitted genomic profile link many

### DIFF
--- a/gdcdictionary/schemas/submitted_genomic_profile.yaml
+++ b/gdcdictionary/schemas/submitted_genomic_profile.yaml
@@ -28,7 +28,7 @@ links:
     backref: submitted_genomic_profiles
     label: data_from
     target_type: read_group
-    multiplicity: one_to_many
+    multiplicity: many_to_many
     required: true
 
 required:
@@ -83,4 +83,4 @@ properties:
       - WGS
 
   read_groups:
-    $ref: "_definitions.yaml#/to_one"
+    $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION
- Relax constraint on submitted genomic profile to read group
from one_to_many to many_to_many