### PR TITLE
chore(pyyaml): Pin pyyaml to 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version="1.15.0",
     packages=find_packages(),
     install_requires=[
-        'PyYAML>=4.2b1',
+        'PyYAML==3.11',
         'jsonschema',
     ],
     package_data={


### PR DESCRIPTION
- Pin pyyaml to 3.11 for release, rolling back bump, we'll fix after oobleck