### PR TITLE
DAT-2373: new molecular test gene symbols

### DIFF
--- a/gdcdictionary/schemas/molecular_test.yaml
+++ b/gdcdictionary/schemas/molecular_test.yaml
@@ -529,6 +529,8 @@ properties:
       - KNL1
       - KNSTRN
       - KRAS
+      - KRT7
+      - KRT20
       - KTN1
       - LARP4B
       - LASP1


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/DAT-2373