### PR TITLE
test(cycles): test for cycles

### DIFF
--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -7,7 +7,7 @@ schema.
 
 """
 
-from utils import validate_schemata, BaseTest
+from .utils import BaseTest, check_for_cycles, validate_schemata
 
 
 class SchemaTest(BaseTest):
@@ -40,3 +40,117 @@ class SchemaTest(BaseTest):
 
     def test_schemas(self):
         validate_schemata(self.dictionary.schema, self.dictionary.metaschema)
+
+    def test_acyclicality(self):
+        """Confirm the dictionary has no (unexpected) cycles."""
+        # File and archive both point to each other. Ignore archive since it's
+        # less relevant than file. The other types should be acyclic.
+        check_for_cycles(self.dictionary.schema, ['archive'])
+
+    def test_acyclicalty_without_ignored_types(self):
+        """
+        Confirm the dictionary has cycles involving the expected type(s).
+
+        If the acyclicality check passes like this, either the algorithm is
+        missing something or we're ignoring types that we shouldn't.
+        """
+        with self.assertRaisesRegexp(AssertionError, 'cycle detected'):
+            check_for_cycles(self.dictionary.schema)
+
+    def test_check_for_cycles_positive(self):
+        """Test the cycle detection logic with a synthetic positive case."""
+
+        # The below schemata cover a few real edge cases; e.g., subgroups,
+        # schemata with no incoming links, schemata with no outgoing links,
+        # and schemata that link back to themselves.
+        schemata = {
+            'analyte': {
+                'links': [
+                    {
+                        'subgroup': [
+                            {'target_type': 'portion'},
+                            {'target_type': 'sample'},
+                        ]
+                    }
+                ]
+            },
+            'case': {
+                'links': [
+                    {'target_type': 'tissue_source_site'},
+                ]
+            },
+            'portion': {
+                'links': [
+                    {'target_type': 'sample'},
+                ]
+            },
+            'sample': {
+                'links': [
+                    {'target_type': 'case'},
+                    {'target_type': 'sample'},
+                    {'target_type': 'tissue_source_site'},
+                ]
+            },
+            'slide': {
+                'links': [
+                    {
+                        'subgroup': [
+                            {'target_type': 'portion'},
+                            {'target_type': 'sample'},
+                        ]
+                    }
+                ]
+            },
+            'tissue_source_site': {'links': []},
+        }
+
+        check_for_cycles(schemata)
+
+    def test_check_for_cycles_negative(self):
+        """Test the cycle detection logic with a synthetic negative case."""
+
+        # There is one cycle involving case, sample, and analyte, and a second
+        # cycle that also includes portion.
+        schemata = {
+            'analyte': {
+                'links': [
+                    {
+                        'subgroup': [
+                            {'target_type': 'portion'},
+                            {'target_type': 'sample'},
+                        ]
+                    }
+                ]
+            },
+            'case': {
+                'links': [
+                    {'target_type': 'analyte'},
+                ]
+            },
+            'portion': {
+                'links': [
+                    {'target_type': 'sample'},
+                ]
+            },
+            'sample': {
+                'links': [
+                    {'target_type': 'case'},
+                    {'target_type': 'sample'},
+                    {'target_type': 'tissue_source_site'},
+                ]
+            },
+            'slide': {
+                'links': [
+                    {
+                        'subgroup': [
+                            {'target_type': 'portion'},
+                            {'target_type': 'sample'},
+                        ]
+                    }
+                ]
+            },
+            'tissue_source_site': {'links': []},
+        }
+
+        with self.assertRaisesRegexp(AssertionError, 'cycle detected'):
+            check_for_cycles(schemata)


### PR DESCRIPTION
Add a test for cyclic links among the various node types. Ignore the existing bidirectional relationship between file and archive since neither is part of the active graph.

I don't know if we need this, but I thought it might be cool.