### PR TITLE
feat(data_release): port root and data_release yamls from dictionaryutils

### DIFF
--- a/gdcdictionary/schemas/data_release.yaml
+++ b/gdcdictionary/schemas/data_release.yaml
@@ -6,7 +6,7 @@ type: object
 namespace: http://gdc.nci.nih.gov
 program: '*'
 project: '*'
-category: internal
+category: data
 description: >
   Internal node to store different data releases.
 additionalProperties: false

--- a/gdcdictionary/schemas/root.yaml
+++ b/gdcdictionary/schemas/root.yaml
@@ -6,7 +6,7 @@ type: object
 program: '*'
 project: '*'
 root: '*'
-category: internal
+category: data
 additionalProperties: false
 submittable: false
 downloadable: false


### PR DESCRIPTION
Ports the files for data release node from dictionaryutils to the gdcdictionary. Dictionaryutils normal has an extra step which loads these yamls before loading the actual gdcdictionary. Moving those yamls in here removes the need for that extra step and also eliminates the dependency