### PR TITLE
DAT-2750: Old request for link between slide and molecular_test

### DIFF
--- a/gdcdictionary/schemas/molecular_test.yaml
+++ b/gdcdictionary/schemas/molecular_test.yaml
@@ -7105,3 +7105,5 @@ properties:
 
   follow_ups:
     $ref: "_definitions.yaml#/to_one"
+  molecular_tests:
+    $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/molecular_test.yaml
+++ b/gdcdictionary/schemas/molecular_test.yaml
@@ -30,6 +30,12 @@ links:
     target_type: follow_up
     multiplicity: many_to_one
     required: true
+  - name: slides
+    backref: molecular_tests
+    label: related_to
+    target_type: slide
+    multiplicity: many_to_one
+    required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/molecular_test.yaml
+++ b/gdcdictionary/schemas/molecular_test.yaml
@@ -7105,5 +7105,5 @@ properties:
 
   follow_ups:
     $ref: "_definitions.yaml#/to_one"
-  molecular_tests:
+  slides:
     $ref: "_definitions.yaml#/to_one"


### PR DESCRIPTION
Per request from IMS, we are getting this change in ASAP because it was missed during a release late in 2019. 

Details can be found here: https://jira.opensciencedatacloud.org/browse/DAT-2750