### PR TITLE
fix(tests): jenkins build with minor updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
--   repo: git@github.com:Yelp/detect-secrets
-    rev: v0.13.0
-    hooks:
-    -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+repos:
+    -   repo: git@github.com:Yelp/detect-secrets
+        rev: v1.1.0
+        hooks:
+        -   id: detect-secrets
+            args: ['--baseline', '.secrets.baseline']
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,8 +1,4 @@
 {
-  "exclude": {
-    "files": "^.secrets.baseline$",
-    "lines": null
-  },
   "generated_at": "2020-11-19T20:50:10Z",
   "plugins_used": [
     {
@@ -12,15 +8,15 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "JwtTokenDetector"
@@ -48,321 +44,386 @@
   "results": {
     "gdcdictionary/examples/invalid/secondary_expression_analysis.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/invalid/secondary_expression_analysis.json",
         "hashed_secret": "4de404c62cf02834719790ee27509d5f61d612e4",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/aggregated_somatic_mutation.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/aggregated_somatic_mutation.json",
         "hashed_secret": "2b38adf3cf0fc7e9584f582470a02b27c01c7257",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/aligned_reads.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/aligned_reads.json",
         "hashed_secret": "4de404c62cf02834719790ee27509d5f61d612e4",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/aligned_reads_index.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/aligned_reads_index.json",
         "hashed_secret": "a1ba33896d16eda8522e531edbaf3b625c1f4c31",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/analysis_metadata.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/analysis_metadata.json",
         "hashed_secret": "daef34f66b6e909f3a22ffd063d48eb428067b6e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/annotated_somatic_mutation.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/annotated_somatic_mutation.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/biospecimen_supplement.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/biospecimen_supplement.json",
         "hashed_secret": "2b38adf3cf0fc7e9584f582470a02b27c01c7257",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/clinical_supplement.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/clinical_supplement.json",
         "hashed_secret": "2b38adf3cf0fc7e9584f582470a02b27c01c7257",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/copy_number_estimate.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/copy_number_estimate.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/copy_number_segment.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/copy_number_segment.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/experiment_metadata.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/experiment_metadata.json",
         "hashed_secret": "daef34f66b6e909f3a22ffd063d48eb428067b6e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/file.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/file.json",
         "hashed_secret": "78b4db9b2aec0f0f2d3e38f9278be42b861c9dc3",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 10,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/filtered_copy_number_segment.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/filtered_copy_number_segment.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/gene_expression.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/gene_expression.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/masked_methylation_array.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/masked_methylation_array.json",
         "hashed_secret": "6953e58b209f030cd00496abdeb8bac65d12d722",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/masked_somatic_mutation.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/masked_somatic_mutation.json",
         "hashed_secret": "2b38adf3cf0fc7e9584f582470a02b27c01c7257",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/methylation_beta_value.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/methylation_beta_value.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/mirna_expression.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/mirna_expression.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/pathology_report.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/pathology_report.json",
         "hashed_secret": "2b38adf3cf0fc7e9584f582470a02b27c01c7257",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/protein_expression.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/protein_expression.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/raw_methylation_array.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/raw_methylation_array.json",
         "hashed_secret": "6953e58b209f030cd00496abdeb8bac65d12d722",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/run_metadata.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/run_metadata.json",
         "hashed_secret": "daef34f66b6e909f3a22ffd063d48eb428067b6e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/seceondary_expression_analysis.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/seceondary_expression_analysis.json",
         "hashed_secret": "4de404c62cf02834719790ee27509d5f61d612e4",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/simple_germline_variation.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/simple_germline_variation.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/simple_somatic_mutation.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/simple_somatic_mutation.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/slide_image.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/slide_image.json",
         "hashed_secret": "daef34f66b6e909f3a22ffd063d48eb428067b6e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/somatic_mutation_index.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/somatic_mutation_index.json",
         "hashed_secret": "a1ba33896d16eda8522e531edbaf3b625c1f4c31",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/structural_variation.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/structural_variation.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/submitted_aligned_reads.json": [
       {
-        "hashed_secret": "7c125229594e0326c6b661746509883bb5e097bb",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/submitted_aligned_reads.json",
+        "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/submitted_genomic_profile.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/submitted_genomic_profile.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/submitted_genotyping_array.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/submitted_genotyping_array.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/submitted_methylation_beta_value.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/submitted_methylation_beta_value.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/submitted_tangent_copy_number.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/submitted_tangent_copy_number.json",
         "hashed_secret": "e3f181b6b92d74e30d524d03029e785d0c7c7535",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "gdcdictionary/examples/valid/submitted_unaligned_reads.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "gdcdictionary/examples/valid/submitted_unaligned_reads.json",
         "hashed_secret": "88e3a7adc1779a311467797f00d2edc5e9697d9c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ]
   },
-  "version": "0.13.0",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "version": "1.1.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^.secrets.baseline$"
+      ]
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 
 install: pip install tox-travis
 script: tox

--- a/gdcdictionary/examples/valid/submitted_aligned_reads.json
+++ b/gdcdictionary/examples/valid/submitted_aligned_reads.json
@@ -4,7 +4,6 @@
     "submitter_id": "TCGA-AB-2837-03B-01W-0728-08",
     "file_name": "C317.TCGA-AB-2837-03B-01W-0728-08.3.bam",
     "file_size": 28165335141,
-    "md5sum": "1d81d9563866362ea36259a64b8898b2",
     "md5sum": "d3266f2577584713ea17f94d331f30c4",
     "data_category": "Sequencing Reads",
     "data_type": "Aligned Reads",

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -1,3 +1,4 @@
+import codecs
 from copy import deepcopy
 from collections import namedtuple
 from contextlib import contextmanager
@@ -65,7 +66,7 @@ class GDCDictionary(object):
         """Return contents of yaml file as dict"""
         # For DAT-1064 Bomb out hard if unicode is in a schema file
         # But allow unicode through the terms and definitions
-        with open(name, 'r', encoding="utf-8") as f:
+        with codecs.open(name, 'r', encoding="utf-8") as f:
             if name not in self.exclude:
                 try:
                     f.read().encode("ascii")

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -65,7 +65,7 @@ class GDCDictionary(object):
         """Return contents of yaml file as dict"""
         # For DAT-1064 Bomb out hard if unicode is in a schema file
         # But allow unicode through the terms and definitions
-        with open(name, 'r') as f:
+        with open(name, 'r', encoding="utf-8") as f:
             if name not in self.exclude:
                 try:
                     f.read().encode("ascii")

--- a/psql-users.sh
+++ b/psql-users.sh
@@ -1,2 +1,2 @@
-psql -U postgres -c "create user test with superuser password 'test';"
+psql -U postgres -c "create user test with superuser password 'test';" # pragma: allowlist secret
 psql -U postgres -c "create database automated_test with owner test;"

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -89,7 +89,8 @@ class SchemaTest(BaseTest):
         If the acyclicality check passes like this, either the algorithm is
         missing something or we're ignoring types that we shouldn't.
         """
-        with self.assertRaisesRegex(AssertionError, 'cycle detected'):
+        # TODO: switch to using assertRaisesRegex after dropping support for python2
+        with self.assertRaisesRegexp(AssertionError, 'cycle detected'):
             check_for_cycles(self.dictionary.schema)
 
     def test_check_for_cycles_positive(self):

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -59,7 +59,6 @@ def _generate_error_message_for_enum(res_dict):
 
 class SchemaTest(BaseTest):
 
-    #@unittest.expectedFailure
     def test_properties_enum(self):
         """Check the enums of node properties"""
         # The enums in _definitions.yaml, _terms.yaml and metaschema.yaml are not checked
@@ -90,7 +89,7 @@ class SchemaTest(BaseTest):
         If the acyclicality check passes like this, either the algorithm is
         missing something or we're ignoring types that we shouldn't.
         """
-        with self.assertRaisesRegexp(AssertionError, 'cycle detected'):
+        with self.assertRaisesRegex(AssertionError, 'cycle detected'):
             check_for_cycles(self.dictionary.schema)
 
     def test_check_for_cycles_positive(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27,py36,py37,py38,py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Jenkins fails with unicode encoding errors, claiming some non ascii characters where found while loading the dictionary. The schemas are loaded using `open` without specifying an encoding, making it platform dependent. The jenkins errors are probably due to jenkins tests using a different default encoding. This PR sets the encoding to utf-8 while loading the dictionary. It uses the `codecs` module since python2.7 open does not allow for specifying encoding