### PR TITLE
feat: use the c library to safeload yaml files

### DIFF
--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -73,7 +73,7 @@ class GDCDictionary(object):
                 except Exception as e:
                     self.logger.error("Error in file: {}".format(name))
                     raise e
-            return yaml.safe_load(f)
+            return yaml.load(f, Loader=yaml.CSafeLoader)
 
     def load_schemas_from_dir(self, directory):
         """Returns all yamls and resolvers of those yamls from dir"""

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -73,7 +73,12 @@ class GDCDictionary(object):
                 except Exception as e:
                     self.logger.error("Error in file: {}".format(name))
                     raise e
-            return yaml.load(f, Loader=yaml.CSafeLoader)
+            try:
+                return yaml.load(f, Loader=yaml.CSafeLoader)
+            except AttributeError as e:
+                self.logger.warning(e)
+                self.logger.warning("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
+                return yaml.safe_load(f)
 
     def load_schemas_from_dir(self, directory):
         """Returns all yamls and resolvers of those yamls from dir"""

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -73,12 +73,11 @@ class GDCDictionary(object):
                 except Exception as e:
                     self.logger.error("Error in file: {}".format(name))
                     raise e
-            try:
+            if yaml.__with_libyaml__:
                 return yaml.load(f, Loader=yaml.CSafeLoader)
-            except AttributeError as e:
-                self.logger.warning(e)
-                self.logger.warning("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
-                return yaml.safe_load(f)
+            self.logger.warning(e)
+            self.logger.warning("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
+            return yaml.safe_load(f)
 
     def load_schemas_from_dir(self, directory):
         """Returns all yamls and resolvers of those yamls from dir"""

--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -75,8 +75,7 @@ class GDCDictionary(object):
                     raise e
             if yaml.__with_libyaml__:
                 return yaml.load(f, Loader=yaml.CSafeLoader)
-            self.logger.warning(e)
-            self.logger.warning("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
+            self.logger.debug("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
             return yaml.safe_load(f)
 
     def load_schemas_from_dir(self, directory):


### PR DESCRIPTION
I tested this by loading the `_terms_enum.yaml` file, which is the largest yaml file in this repo. `safe_load` took just over 7 seconds to complete. Using `CSafeLoader` as the loader took just over 1 second to complete.

`CSafeLoader` can only be imported if libyaml is installed locally. If it still says that `CSafeLoader` cannot be imported then delete the pip wheel cache. The feature is only enabled when pip installs the library, not when the module is imported, which is sort of confusing.

Linux:
```~/.cache/pip```

Mac:
```~/Library/Caches/pip```

Windows:
```%LocalAppData%\pip\Cache```