### PR TITLE
Update exon ref.

### DIFF
--- a/src/gdcdictionary/schemas/tag.yaml
+++ b/src/gdcdictionary/schemas/tag.yaml
@@ -119,4 +119,4 @@ properties:
     enumDef:
       exon:
         $ref:
-          - "_terms_enum.yaml#/exon/common"
+          - "_terms_enum.yaml#/exon/tag/name"


### PR DESCRIPTION
`exon/common` was removed. Ref must point to tag.