### PR TITLE
DEV-1862: Pin gitlab templates to 0.1.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 
 include:
   - project: nci-gdc/gitlab-templates
-    ref: master
+    ref: 0.1.0
     file:
       - templates/global/full.yaml
       - templates/python/full.yaml


### PR DESCRIPTION
gitlab usage is this project is currently not compatible with gitlab template 0.2.0, this PR pins templates to 0.1.0