### PR TITLE
chore(fix): remove non-ascii character from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gdcdictionary
-description = The Genomic Data Commons’ (GDC) data dictionary
+description = The Genomic Data Commons (GDC) data dictionary
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Gdc feature team


### PR DESCRIPTION
Removes non-ascii character from setup.cfg which is preventing installation on VMs