### PR TITLE
Changed enums for Inoue dictionary release

### DIFF
--- a/src/gdcdictionary/schemas/read_group.yaml
+++ b/src/gdcdictionary/schemas/read_group.yaml
@@ -182,6 +182,7 @@ properties:
       - Illumina MiSeq
       - Illumina NextSeq
       - Illumina NovaSeq 6000
+      - Illumina NovaSeq X
       - Ion Torrent PGM
       - Ion Torrent Proton
       - Ion Torrent S5

--- a/src/gdcdictionary/schemas/submitted_aligned_reads.yaml
+++ b/src/gdcdictionary/schemas/submitted_aligned_reads.yaml
@@ -84,10 +84,11 @@ properties:
       - miRNA-Seq
       - RNA-Seq
       - scATAC-Seq
-      - scRNA-Seq
       - Targeted Sequencing
       - WGS
       - WXS
+    deprecated_enum:
+      - scRNA-Seq
     enumDef:
       Targeted Sequencing:
         $ref:


### PR DESCRIPTION
Added new enum "Illumina NovaSeq X" for read_group.instrument_model 
Deprecated enum "scRNA-Seq" for submitted_aligned_reads.experimental_strategy