### PR TITLE
Updating read_group node for Inoue DICT-339

### DIFF
--- a/src/gdcdictionary/schemas/read_group.yaml
+++ b/src/gdcdictionary/schemas/read_group.yaml
@@ -182,6 +182,7 @@ properties:
       - Illumina MiSeq
       - Illumina NextSeq
       - Illumina NovaSeq 6000
+      - Illumina NovaSeq X
       - Ion Torrent PGM
       - Ion Torrent Proton
       - Ion Torrent S5


### PR DESCRIPTION
Updating read_group node to include new enum "Illumina NovaSeq X" for property instrument_model
DICT Jira ticket: https://gdc-ctds.atlassian.net/browse/DICT-339