### PR TITLE
DEV 2011 except tags for push_datamodels_to_github

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,8 @@ push_datamodels_to_github:
   allow_failure: true   # failure when no changes of models
   dependencies:
     - execute_plaster
+  except:
+    - tags
 
 
 push_datamodels_tag_to_github:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,8 +76,6 @@ push_datamodels_tag_to_github:
   stage: tag_gdcdatamodel2
   script:
     - !reference [ .load_github_key, script ]
-    # can not use artifact from previous stage because previous stage is allowed to fail
-#    - git clone git@github.com:NCI-GDC/gdcdatamodel2.git
     - cd gdcdatamodel2
     - git push origin --delete "$CI_COMMIT_REF_NAME" || true # delete branch with tag name
     - git log -1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ push_datamodels_tag_to_github:
     - echo "gdcdictionary $CI_COMMIT_SHORT_SHA gdcdatamodel2 $(git rev-parse --short HEAD)"
     - git tag -a $CI_COMMIT_TAG -m "gdcdictionary $CI_COMMIT_SHORT_SHA gdcdatamodel2 $(git rev-parse --short HEAD)"
     - git push origin $CI_COMMIT_TAG
-  only:
-    - tags
   dependencies:
     - push_datamodels_to_github
+  only:
+    - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,9 +60,9 @@ push_datamodels_to_github:
     - cat setup.cfg
     - git status
     - git add .
-    - git commit -m "Use gdcdictionary $CI_COMMIT_REF_NAME $CI_COMMIT_SHA"
+    - git commit -m "Use gdcdictionary $CI_COMMIT_REF_NAME $CI_COMMIT_SHA" || true
+    - git rev-parse --short HEAD
     - git push origin "$CI_COMMIT_REF_NAME"
-#  allow_failure: true   # failure when no changes of models
   dependencies:
     - execute_plaster
   artifacts:
@@ -83,7 +83,7 @@ push_datamodels_tag_to_github:
     - git log -1
     - echo "gdcdictionary $CI_COMMIT_SHORT_SHA gdcdatamodel2 $(git rev-parse --short HEAD)"
     - git tag -a $CI_COMMIT_TAG -m "gdcdictionary $CI_COMMIT_SHORT_SHA gdcdatamodel2 $(git rev-parse --short HEAD)"
-    - git push origin $CI_COMMIT_TAG
+    - git push --tags
   dependencies:
     - push_datamodels_to_github
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,9 +62,13 @@ push_datamodels_to_github:
     - git add .
     - git commit -m "Use gdcdictionary $CI_COMMIT_REF_NAME $CI_COMMIT_SHA"
     - git push origin "$CI_COMMIT_REF_NAME"
-  allow_failure: true   # failure when no changes of models
+#  allow_failure: true   # failure when no changes of models
   dependencies:
     - execute_plaster
+  artifacts:
+    paths:
+      - gdcdatamodel2
+    expire_in: 1 week
 
 
 push_datamodels_tag_to_github:
@@ -72,10 +76,10 @@ push_datamodels_tag_to_github:
   stage: tag_gdcdatamodel2
   script:
     - !reference [ .load_github_key, script ]
-    - git push origin --delete "$CI_COMMIT_REF_NAME" || true # delete branch with tag name
     # can not use artifact from previous stage because previous stage is allowed to fail
-    - git clone git@github.com:NCI-GDC/gdcdatamodel2.git
+#    - git clone git@github.com:NCI-GDC/gdcdatamodel2.git
     - cd gdcdatamodel2
+    - git push origin --delete "$CI_COMMIT_REF_NAME" || true # delete branch with tag name
     - git log -1
     - echo "gdcdictionary $CI_COMMIT_SHORT_SHA gdcdatamodel2 $(git rev-parse --short HEAD)"
     - git tag -a $CI_COMMIT_TAG -m "gdcdictionary $CI_COMMIT_SHORT_SHA gdcdatamodel2 $(git rev-parse --short HEAD)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,8 +65,6 @@ push_datamodels_to_github:
   allow_failure: true   # failure when no changes of models
   dependencies:
     - execute_plaster
-  except:
-    - tags
 
 
 push_datamodels_tag_to_github:
@@ -74,6 +72,7 @@ push_datamodels_tag_to_github:
   stage: tag_gdcdatamodel2
   script:
     - !reference [ .load_github_key, script ]
+    - git push origin --delete "$CI_COMMIT_REF_NAME" || true # delete branch with tag name
     # can not use artifact from previous stage because previous stage is allowed to fail
     - git clone git@github.com:NCI-GDC/gdcdatamodel2.git
     - cd gdcdatamodel2


### PR DESCRIPTION
https://gdc-ctds.atlassian.net/browse/DEV-2011

Previously the GitLab pipeline pushes branches to gdcdatamodel2 for new tags from gdcdictionary.
Add this will avoid that.

Tags of gdcdictionary should only push tags for gdcdatamodel2. 