### PR TITLE
DEV-2738: add json schema validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ admin_auth
 # IDEs
 .vscode/
 .idea/
+results.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,11 @@ install_requires =
 [options.packages.find]
 where = src
 
+[options.package_data]
+gdcdictionary =
+    schemas/*.yaml
+    schemas/projects/*.yaml
+
 [options.extras_require]
 changelog =
     towncrier

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     PyYAML
     jsonschema
     attrs
-
+    importlib_resources; python_version < '3.9'
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     PyYAML
     jsonschema
     attrs
-    importlib_resources; python_version < '3.9'
+    importlib_resources >= 1.3; python_version < '3.9'
 
 [options.packages.find]
 where = src

--- a/src/gdcdictionary/__init__.py
+++ b/src/gdcdictionary/__init__.py
@@ -1,7 +1,17 @@
-import os
+from gdcdictionary.core import GDCDictionary, gdcdictionary, get_schema_directory
+from gdcdictionary.validators import (
+    SchemaValidator,
+    SchemaValidationError,
+    validate,
+    validate_instances,
+)
 
-from gdcdictionary.python import GDCDictionary, gdcdictionary
-
-
-
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+__all__ = [
+    "gdcdictionary",
+    "get_schema_directory",
+    "validate",
+    "validate_instances",
+    "GDCDictionary",
+    "SchemaValidator",
+    "SchemaValidationError",
+]

--- a/src/gdcdictionary/core.py
+++ b/src/gdcdictionary/core.py
@@ -7,7 +7,7 @@ try:
     from importlib.resources import files
 except ImportError:
     from importlib_resources import files
-from typing import Optional, List
+from typing import Optional, List, Tuple, Dict, Any
 
 from jsonschema import RefResolver
 
@@ -88,7 +88,7 @@ class GDCDictionary:
             logger.debug("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
             return yaml.safe_load(f)
 
-    def load_schemas_from_dir(self, directory: pathlib.Path):
+    def load_schemas_from_dir(self, directory: pathlib.Path) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Returns all yamls and resolvers of those yamls from dir"""
 
         schemas, resolvers = {}, {}
@@ -101,7 +101,7 @@ class GDCDictionary:
 
         return schemas, resolvers
 
-    def load_directory(self, directory: pathlib.Path):
+    def load_directory(self, directory: pathlib.Path) -> None:
         """Load and resolve all schemas from directory"""
 
         yamls, resolvers = self.load_schemas_from_dir(directory)

--- a/src/gdcdictionary/core.py
+++ b/src/gdcdictionary/core.py
@@ -1,31 +1,39 @@
+import logging
+import pathlib
 from copy import deepcopy
 from collections import namedtuple
-from contextlib import contextmanager
+
+from importlib import resources
+from typing import Optional, List
+
 from jsonschema import RefResolver
 
-import glob
-import logging
-import os
 import yaml
 
-MOD_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 
+logger = logging.getLogger(__name__)
 ResolverPair = namedtuple('ResolverPair', ['resolver', 'source'])
 
 
-@contextmanager
-def visit_directory(path):
-    """Perform contained actions with current working directory at
-    :param:``path``.  Always return to previous directory when done.
+def get_schema_directory(local_path: Optional[str] = None) -> pathlib.Path:
+    """Resolve the directory containing the schema definitions files.
 
+    Args:
+        local_path: custom location for the schema
+    Returns:
+        the schema directory as path object.
     """
+    if local_path:
+        path = pathlib.Path(local_path)
 
-    cdir = os.getcwd()
-    try:
-        os.chdir(path)
-        yield os.getcwd()
-    finally:
-        os.chdir(cdir)
+        if not path.exists():
+            raise IOError("Specified template directory '%s' does not exist", path)
+        return path
+
+        # use default embedded location
+    with resources.path("gdcdictionary", "schemas") as path:
+        logger.info(path)
+        return path
 
 
 class GDCDictionary:
@@ -37,10 +45,8 @@ class GDCDictionary:
         '_terms_enum.yaml',
     ]
 
-    logger = logging.getLogger("GDCDictionary")
-
-    def __init__(self, lazy=False, root_dir=None, definitions_paths=None,
-                 metaschema_path=None):
+    def __init__(self, lazy: bool = False, root_dir: Optional[str] = None, definitions_paths: Optional[List[str]] = None,
+                 metaschema_path: Optional[str] = None):
         """Creates a new dictionary instance.
 
         :param root_dir: The directory to find schemas
@@ -50,13 +56,14 @@ class GDCDictionary:
 
         """
 
+        self.loaded = False
         self.metaschema = None
 
-        self.root_dir = (root_dir or os.path.join(MOD_DIR, 'schemas'))
+        self.root_dir = get_schema_directory(root_dir)
         self.metaschema_path = metaschema_path or self._metaschema_path
         self.definitions_paths = definitions_paths or self._definitions_paths
         self.exclude = [self.metaschema_path] + self.definitions_paths
-        self.schema = dict()
+        self._schema = dict()
         self.resolvers = dict()
         if not lazy:
             self.load_directory(self.root_dir)
@@ -71,29 +78,28 @@ class GDCDictionary:
                     f.read().encode("ascii")
                     f.seek(0)
                 except Exception as e:
-                    self.logger.error(f"Error in file: {name}")
+                    logger.error(f"Error in file: {name}")
                     raise e
             if yaml.__with_libyaml__:
                 return yaml.load(f, Loader=yaml.CSafeLoader)
-            self.logger.debug("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
+            logger.debug("To enable CSafeLoader install libyaml. Falling back to yaml.safe_load()")
             return yaml.safe_load(f)
 
-    def load_schemas_from_dir(self, directory):
+    def load_schemas_from_dir(self, directory: pathlib.Path):
         """Returns all yamls and resolvers of those yamls from dir"""
 
         schemas, resolvers = {}, {}
 
-        with visit_directory(directory):
-            for path in glob.glob("*.yaml"):
-                schema = self.load_yaml(path)
-                schemas[path] = schema
-                resolver = RefResolver(f'{path}#', schema)
-                resolvers[path] = ResolverPair(resolver, schema)
+        for path in directory.glob("*.yaml"):
+            schema = self.load_yaml(path)
+            schemas[path.name] = schema
+            resolver = RefResolver(f'{path.name}#', schema)
+            resolvers[path.name] = ResolverPair(resolver, schema)
 
         return schemas, resolvers
 
-    def load_directory(self, directory):
-        """Load and reslove all schemas from directory"""
+    def load_directory(self, directory: pathlib.Path):
+        """Load and resolve all schemas from directory"""
 
         yamls, resolvers = self.load_schemas_from_dir(directory)
 
@@ -105,7 +111,8 @@ class GDCDictionary:
             for path, schema in yamls.items()
             if path not in self.exclude
         }
-        self.schema.update(schemas)
+        self._schema.update(schemas)
+        self.loaded = True
 
     def resolve_reference(self, value, root):
         """Resolves a reference.
@@ -163,5 +170,11 @@ class GDCDictionary:
         for ref in refs:
             obj.update(self.resolve_reference(ref, root))
 
+    @property
+    def schema(self) -> dict:
+        if not self.loaded:
+            self.load_directory(self.root_dir)
+        return self._schema
 
-gdcdictionary = GDCDictionary()
+
+gdcdictionary = GDCDictionary(lazy=True)

--- a/src/gdcdictionary/core.py
+++ b/src/gdcdictionary/core.py
@@ -3,7 +3,10 @@ import pathlib
 from copy import deepcopy
 from collections import namedtuple
 
-from importlib import resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 from typing import Optional, List
 
 from jsonschema import RefResolver
@@ -30,8 +33,8 @@ def get_schema_directory(local_path: Optional[str] = None) -> pathlib.Path:
             raise IOError("Specified template directory '%s' does not exist", path)
         return path
 
-        # use default embedded location
-    with resources.path("gdcdictionary", "schemas") as path:
+    # use default embedded location
+    with files("gdcdictionary").joinpath("schemas") as path:
         logger.info(path)
         return path
 

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -1,0 +1,92 @@
+"""JSON validator module for validating user supplied json documents."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List, NamedTuple, Dict, Optional, Iterable
+
+from gdcdictionary import gdcdictionary
+from jsonschema import Draft4Validator
+
+
+logger = logging.getLogger(__name__)
+missing_prop_re = re.compile(r"('[a-zA-Z_-]+')+")
+_validators: Dict[str, SchemaValidator] = {}
+
+
+def _parse_keys_from_error_message(error_msg: str) -> List[str]:
+    missing_prop = missing_prop_re.findall(error_msg)
+    return [m.replace("\'", "") for m in missing_prop]
+
+
+class SchemaValidationError(NamedTuple):
+    schema: str
+    message: str
+    keys: List[str]
+
+
+class SchemaValidator:
+    """Validator for individual schemas in the dictionary.
+
+    Properties:
+        name: name of specific dictionary schema
+        validator: json validator initialized with the schema
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.validator = Draft4Validator(gdcdictionary.schema[name])
+
+    def post_validate(self, violations: List[SchemaValidationError]):
+        ...
+
+    def iter_errors(self, json_instance: Any) -> List[SchemaValidationError]:
+        violations: List[SchemaValidationError] = []
+        for error in self.validator.iter_errors(instance=json_instance):
+            # the key will be  property.sub property for nested properties
+            errors = [str(e) for e in error.path if error.path]
+            keys = [".".join(errors)] if errors else []
+            if not keys:
+                keys = _parse_keys_from_error_message(error.message)
+            message = error.message
+            if error.context:
+                message += ": {}".format(
+                    " and ".join([c.message for c in error.context])
+                )
+            violations.append(SchemaValidationError(self.name, message, keys))
+        self.post_validate(violations)
+        return violations
+
+
+def _get_validator(schema_name: str) -> Optional[SchemaValidator]:
+    if schema_name not in _validators and schema_name not in gdcdictionary.schema:
+        logger.warning("Unknown schema name specified %s", schema_name)
+        return None
+    _validators[schema_name] = SchemaValidator(schema_name)
+    return _validators[schema_name]
+
+
+def validate(instance: dict) -> List[SchemaValidationError]:
+    if "type" not in instance:
+        return [
+            SchemaValidationError(
+                schema="", message="'type' is a required property", keys=["type"]
+            )
+        ]
+    validator = _get_validator(instance["type"])
+    if not validator:
+        return [
+            SchemaValidationError(
+                schema="",
+                message=f"specified type: {instance['type']} is not in the current data model",
+                keys=["type"],
+            )
+        ]
+    return validator.iter_errors(instance)
+
+
+def validate_instances(instances: Iterable[dict]) -> List[SchemaValidationError]:
+    violations: List[SchemaValidationError] = []
+    for instance in instances:
+        violations += validate(instance)
+    return violations

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -1,4 +1,19 @@
-"""JSON validator module for validating user supplied json documents."""
+"""JSON validator module for validating user supplied json documents.
+
+Example:
+    .. code-block:: python
+        import gdcdictionary
+
+        # single
+        instance = {'type': 'case', 'disease_type': 'bad disease'}
+        for violation in gdcdictionary.validate(instance):
+           print(violation.message, violation.keys)
+
+        # multiple
+        for violation in gdcdictionary.validate_instances([instance]):
+            ...
+
+"""
 from __future__ import annotations
 
 import logging
@@ -10,19 +25,40 @@ from jsonschema import Draft4Validator
 
 
 logger = logging.getLogger(__name__)
-missing_prop_re = re.compile(r"('[a-zA-Z_-]+')+")
+invalid_property_regex = re.compile(r"('[a-zA-Z_-]+')+")
 _validators: Dict[str, SchemaValidator] = {}
 
 
 def _parse_keys_from_error_message(error_msg: str) -> List[str]:
-    missing_prop = missing_prop_re.findall(error_msg)
-    return [m.replace("\'", "") for m in missing_prop]
+    missing_prop = invalid_property_regex.findall(error_msg)
+    return [m.replace("'", "") for m in missing_prop]
 
 
 class SchemaValidationError(NamedTuple):
+    """A single schema violation representation.
+
+    Properties:
+        schema: the name of the json schema e.g. aliquot
+        message: the error message describing the violation
+        keys: the list of keys whose constraints were violated.
+    """
+
     schema: str
     message: str
     keys: List[str]
+
+    @classmethod
+    def from_values(
+        cls, schema: str, message: str, keys: List[str]
+    ) -> SchemaValidationError:
+        if "Additional properties are not allowed" in message:
+            message = f"Key(s) {keys} not a valid property for type '{schema}'"
+        logger.debug(
+            "json schema violation for '%s'",
+            schema,
+            extra={"keys": keys, "message": message},
+        )
+        return SchemaValidationError(schema, message, keys)
 
 
 class SchemaValidator:
@@ -37,11 +73,17 @@ class SchemaValidator:
         self.name = name
         self.validator = Draft4Validator(gdcdictionary.schema[name])
 
-    def post_validate(self, violations: List[SchemaValidationError]):
+    def post_validate(self, violations: List[SchemaValidationError]) -> None:
+        """Implements further validations and/or filtering here."""
+        ...
+
+    def pre_validate(self, json_instance: Any) -> None:
+        """Implements any prior work to be done on the json before validation."""
         ...
 
     def iter_errors(self, json_instance: Any) -> List[SchemaValidationError]:
         violations: List[SchemaValidationError] = []
+        self.pre_validate(json_instance)
         for error in self.validator.iter_errors(instance=json_instance):
             # the key will be  property.sub property for nested properties
             errors = [str(e) for e in error.path if error.path]
@@ -53,7 +95,9 @@ class SchemaValidator:
                 message += ": {}".format(
                     " and ".join([c.message for c in error.context])
                 )
-            violations.append(SchemaValidationError(self.name, message, keys))
+            violations.append(
+                SchemaValidationError.from_values(self.name, message, keys)
+            )
         self.post_validate(violations)
         return violations
 
@@ -67,6 +111,17 @@ def _get_validator(schema_name: str) -> Optional[SchemaValidator]:
 
 
 def validate(instance: dict) -> List[SchemaValidationError]:
+    """Validate a single json instance.
+
+    `type` is handled specially as it is not defined as a required field in
+    the dictionary, but is required to correctly figure out the target schema.
+
+    Args:
+        instance: json instance
+
+    Returns:
+        a list of errors
+    """
     if "type" not in instance:
         return [
             SchemaValidationError(
@@ -86,6 +141,14 @@ def validate(instance: dict) -> List[SchemaValidationError]:
 
 
 def validate_instances(instances: Iterable[dict]) -> List[SchemaValidationError]:
+    """Validate multiple json instances.
+
+    Args:
+        instances: list of json documents.
+
+    Returns:
+        list of errors
+    """
     violations: List[SchemaValidationError] = []
     for instance in instances:
         violations += validate(instance)

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -73,17 +73,8 @@ class SchemaValidator:
         self.name = name
         self.validator = Draft4Validator(gdcdictionary.schema[name])
 
-    def post_validate(self, violations: List[SchemaValidationError]) -> None:
-        """Implements further validations and/or filtering here."""
-        ...
-
-    def pre_validate(self, json_instance: Any) -> None:
-        """Implements any prior work to be done on the json before validation."""
-        ...
-
     def iter_errors(self, json_instance: Any) -> List[SchemaValidationError]:
         violations: List[SchemaValidationError] = []
-        self.pre_validate(json_instance)
         for error in self.validator.iter_errors(instance=json_instance):
             # the key will be  property.sub property for nested properties
             errors = [str(e) for e in error.path if error.path]
@@ -98,7 +89,6 @@ class SchemaValidator:
             violations.append(
                 SchemaValidationError.from_values(self.name, message, keys)
             )
-        self.post_validate(violations)
         return violations
 
 
@@ -110,7 +100,7 @@ def _get_validator(schema_name: str) -> Optional[SchemaValidator]:
     return _validators[schema_name]
 
 
-def validate(instance: dict) -> List[SchemaValidationError]:
+def validate(instance: Dict[str, Any]) -> List[SchemaValidationError]:
     """Validate a single json instance.
 
     `type` is handled specially as it is not defined as a required field in
@@ -140,7 +130,7 @@ def validate(instance: dict) -> List[SchemaValidationError]:
     return validator.iter_errors(instance)
 
 
-def validate_instances(instances: Iterable[dict]) -> List[SchemaValidationError]:
+def validate_instances(instances: Iterable[Dict[str, Any]]) -> List[SchemaValidationError]:
     """Validate multiple json instances.
 
     Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 """
     Conftest.py a configuration file for pytest
 """
-import os
 
 import pytest
-from src.gdcdictionary import ROOT_DIR, GDCDictionary
+from gdcdictionary import GDCDictionary
 from tests.utils import load_yaml
 
 
@@ -15,8 +14,7 @@ def dictionary():
 
 @pytest.fixture(scope="session")
 def definitions(dictionary):
-    # TODO why not pkg_resources
-    return load_yaml(os.path.join(ROOT_DIR, 'schemas', '_definitions.yaml'))
+    return load_yaml('_definitions.yaml')
 
 
 @pytest.fixture(scope="session")

--- a/tests/json_validation_test.py
+++ b/tests/json_validation_test.py
@@ -7,30 +7,70 @@ Note this is NOT testing that the schema is sane. Just that we adhere
 to it
 
 """
-
-from tests.utils import DATA_DIR
-from jsonschema import validate, ValidationError
+from importlib import resources
 
 import json
-import glob
-import os
 import pytest
 
+import gdcdictionary
 
-def get_all_paths(subdir):
-    yield from sorted(glob.glob(os.path.join(DATA_DIR, subdir, '*.json')))
+
+def get_all_paths(subdir: str) -> str:
+    with resources.path("tests", ".") as path:
+        examples_path = path.parent / f"examples/{subdir}"
+        yield from sorted(examples_path.glob("*.json"))
 
 
 @pytest.mark.parametrize("path", get_all_paths("valid"))
 def test_valid_examples(path, schema):
     with open(path) as f:
         doc = json.load(f)
-        validate(doc, schema[doc["type"]])
+        assert len(gdcdictionary.validate(doc)) == 0
 
 
 @pytest.mark.parametrize("path", get_all_paths("invalid"))
 def test_invalid_examples(path, schema):
     with open(path) as f:
         doc = json.load(f)
-        with pytest.raises(ValidationError):
-            validate(doc, schema[doc["type"]])
+        violations = gdcdictionary.validate(doc)
+        assert len(violations) > 0
+        print(violations)
+
+
+def test_validate_instances():
+    paths = get_all_paths("valid")
+    instances = []
+    for path in paths:
+        with open(path) as f:
+            doc = json.load(f)
+            instances.append(doc)
+    violations = gdcdictionary.validate_instances(instances)
+    assert len(violations) == 0
+
+
+def test_validate_instances__invalid_types():
+    instances = [
+        {"type": "species"},
+        {"type": "case", "python_version": "38"},
+        {"name": "species"},
+    ]
+    violations = gdcdictionary.validate_instances(instances)
+    assert len(violations) > 2
+
+    unknown_types = [v for v in violations if v.schema == ""]
+    assert len(unknown_types) == 2
+
+    case_required_field_violation = next(
+        v for v in violations if v.schema == "case" and v.keys == ["submitter_id"]
+    )
+    assert (
+        case_required_field_violation.message == "'submitter_id' is a required property"
+    )
+
+    case_extra_field_violation = next(
+        v for v in violations if v.schema == "case" and v.keys == ["python_version"]
+    )
+    assert (
+        case_extra_field_violation.message
+        == "Additional properties are not allowed ('python_version' was unexpected)"
+    )

--- a/tests/json_validation_test.py
+++ b/tests/json_validation_test.py
@@ -7,7 +7,10 @@ Note this is NOT testing that the schema is sane. Just that we adhere
 to it
 
 """
-from importlib import resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 import json
 import pytest
@@ -16,7 +19,7 @@ import gdcdictionary
 
 
 def get_all_paths(subdir: str) -> str:
-    with resources.path("tests", ".") as path:
+    with files("tests") as path:
         examples_path = path.parent / f"examples/{subdir}"
         yield from sorted(examples_path.glob("*.json"))
 

--- a/tests/test_gdcdictionary.py
+++ b/tests/test_gdcdictionary.py
@@ -1,4 +1,7 @@
-from importlib import resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 import pytest
 
@@ -11,6 +14,6 @@ def test_load_dictionary__invalid_location() -> None:
 
 
 def test_load_dictionary() -> None:
-    with resources.path("tests", ".") as path:
+    with files("tests") as path:
         dictionary = gdcdictionary.GDCDictionary(root_dir=str(path.parent / "src/gdcdictionary/schemas"), lazy=False)
         assert dictionary.loaded is True

--- a/tests/test_gdcdictionary.py
+++ b/tests/test_gdcdictionary.py
@@ -1,0 +1,16 @@
+from importlib import resources
+
+import pytest
+
+import gdcdictionary
+
+
+def test_load_dictionary__invalid_location() -> None:
+    with pytest.raises(IOError):
+        gdcdictionary.GDCDictionary(root_dir="invalid/dir/path")
+
+
+def test_load_dictionary() -> None:
+    with resources.path("tests", ".") as path:
+        dictionary = gdcdictionary.GDCDictionary(root_dir=str(path.parent / "src/gdcdictionary/schemas"), lazy=False)
+        assert dictionary.loaded is True

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -52,6 +52,15 @@ def test_validate_instances() -> None:
 
 
 def test_validate_instances__invalid_types() -> None:
+    """Test validating multiple documents at the same time.
+
+    Test data is chosen to cover three scenarios:
+        * missing `type` property
+        * unexpected property
+        * unknown type - type does not match a known schema
+
+    The test does not cover every possible scenario that causes a violation.
+    """
     instances = [
         {"type": "species"},
         {"type": "case", "python_version": "38"},

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -75,5 +75,5 @@ def test_validate_instances__invalid_types():
     )
     assert (
         case_extra_field_violation.message
-        == "Additional properties are not allowed ('python_version' was unexpected)"
+        == "Key(s) ['python_version'] not a valid property for type 'case'"
     )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -40,7 +40,7 @@ def test_invalid_examples(path, schema):
         print(violations)
 
 
-def test_validate_instances():
+def test_validate_instances() -> None:
     paths = get_all_paths("valid")
     instances = []
     for path in paths:
@@ -51,13 +51,15 @@ def test_validate_instances():
     assert len(violations) == 0
 
 
-def test_validate_instances__invalid_types():
+def test_validate_instances__invalid_types() -> None:
     instances = [
         {"type": "species"},
         {"type": "case", "python_version": "38"},
         {"name": "species"},
     ]
     violations = gdcdictionary.validate_instances(instances)
+    print(violations)
+
     assert len(violations) > 2
 
     unknown_types = [v for v in violations if v.schema == ""]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,21 +6,24 @@ specific overrrides are not being used in the GDC currently.
 from collections import defaultdict
 import copy
 import os
+from typing import Optional
+
 import yaml
 import unittest
 
 from jsonschema import validate
 
-from src.gdcdictionary import ROOT_DIR, GDCDictionary
+import gdcdictionary
+from gdcdictionary import GDCDictionary
 
 
-def load_yaml(path):
-    with open(path) as f:
+def load_yaml(path, root: Optional[str] = None):
+    schema_path = gdcdictionary.get_schema_directory(root) / path
+    with schema_path.open() as f:
         return yaml.safe_load(f)
 
 
-DATA_DIR = os.path.join(ROOT_DIR, 'examples')
-project1 = load_yaml(os.path.join(ROOT_DIR, 'schemas/projects/project1.yaml'))
+project1 = load_yaml('projects/project1.yaml')
 projects = {'project1': project1}
 
 
@@ -28,7 +31,7 @@ class BaseTest(unittest.TestCase):
 
     def setUp(self):
         self.dictionary = GDCDictionary()
-        self.definitions = load_yaml(os.path.join(ROOT_DIR, 'schemas', '_definitions.yaml'))
+        self.definitions = load_yaml('_definitions.yaml')
 
 
 def merge_schemas(a, b, path=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ specific overrrides are not being used in the GDC currently.
 
 from collections import defaultdict
 import copy
-import os
 from typing import Optional
 
 import yaml

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ extras =
     dev
 commands =
     env
-    pytest -lvv --cov=gdcdictionary --cov-report xml --cov-report html --junit-xml test-reports/results.xml {posargs}
+    pytest -lvv --cov=gdcdictionary --cov-report xml --cov-report html --cov-report term --junit-xml results.xml {posargs}
 
 [testenv:publish]
 changedir =


### PR DESCRIPTION
Add validator module with functions that validates a user supplied json document. Minor refactoring on the gdcdictionary module by doing the following:
* Rename python/__init__.py to core.py
* Replace path traversal with importlib-resources files which is more consistent with loading resources in python
* Refactor tests to use importlib-resources as well