### PR TITLE
DEV-2762: optional submitter id in partial documents validation

### DIFF
--- a/src/gdcdictionary/core.py
+++ b/src/gdcdictionary/core.py
@@ -34,7 +34,6 @@ def get_schema_directory(local_path: Optional[str] = None) -> pathlib.Path:
 
     # use default embedded location
     with files("gdcdictionary").joinpath("schemas") as path:
-        logger.info(path)
         return path
 
 

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -64,7 +64,7 @@ class SchemaValidationError(NamedTuple):
 
     @property
     def is_ignored_for_partials(self) -> bool:
-        return self.is_required_field_violation and "submitter_id" not in self.keys
+        return self.is_required_field_violation
 
     @classmethod
     def from_values(cls, schema: str, message: str, keys: List[str]) -> SchemaValidationError:
@@ -154,6 +154,14 @@ def validate(instance: Dict[str, Any], partial: bool = False) -> List[SchemaVali
         return [
             SchemaValidationError(
                 schema="", message="'type' is a required property", keys=["type"]
+            )
+        ]
+    if "submitter_id" not in instance and "id" not in instance:
+        return [
+            SchemaValidationError(
+                schema=instance["type"],
+                message="one of ['submitter_id', 'id'] is required.",
+                keys=["submitter_id", "id"],
             )
         ]
     validator = _get_validator(instance["type"])

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -164,17 +164,17 @@ def validate(instance: Dict[str, Any], partial: bool = False) -> List[SchemaVali
     ):
         return [
             SchemaValidationError(
-                schema=instance["type"],
+                schema=schema_type,
                 message="one of ['submitter_id', 'id'] is required.",
                 keys=["submitter_id", "id"],
             )
         ]
-    validator = _get_validator(instance["type"])
+    validator = _get_validator(schema_type)
     if not validator:
         return [
             SchemaValidationError(
                 schema="",
-                message=f"specified type: {instance['type']} is not in the current data model",
+                message=f"specified type: {schema_type} is not in the current data model",
                 keys=["type"],
             )
         ]

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -17,11 +17,21 @@ Example:
 Partial documents are json documents for a specific type but potentially
 missing some required fields. All supplied values should be valid based on
 the constraints defined in the target schema. The example instance above
-is a partial case document and can be partially validated using
+is a partial case document and can be partially validated using.
 
+The minimum required fields for partial documents are:
+    * type
+    * one of:
+        ** id
+        ** submitter_id
+
+>>> import uuid
 >>> import gdcdictionary
->>> instance = {'type': 'case', 'submitter_id': 'UNSC-1', 'disease_type': 'Not Applicable'}
->>> gdcdictionary.validate(instance, partial=True)
+>>> instances = [\
+    {'type': 'case', 'submitter_id': 'UNSC-1', 'disease_type': 'Not Applicable'},\
+    {'type': 'case', 'id': str(uuid.uuid4()), 'disease_type': 'Not Applicable'}\
+]
+>>> gdcdictionary.validate_instances(instances, partial=True)
 []
 """
 

--- a/src/gdcdictionary/validators.py
+++ b/src/gdcdictionary/validators.py
@@ -156,7 +156,12 @@ def validate(instance: Dict[str, Any], partial: bool = False) -> List[SchemaVali
                 schema="", message="'type' is a required property", keys=["type"]
             )
         ]
-    if "submitter_id" not in instance and "id" not in instance:
+    schema_type = instance["type"]
+    if (
+        schema_type not in ["program", "project"]
+        and "submitter_id" not in instance
+        and "id" not in instance
+    ):
         return [
             SchemaValidationError(
                 schema=instance["type"],

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,6 +8,8 @@ to it
 
 """
 
+import uuid
+
 try:
     from importlib.resources import files
 except ImportError:
@@ -66,7 +68,8 @@ def test_validate_instances__invalid_types(partial: bool) -> None:
     """
     instances = [
         {"type": "species"},
-        {"type": "case", "python_version": "38"},
+        {"type": "case", "submitter_id": "unsc-0", "python_version": "38"},
+        {"type": "aliquot", "python_version": "38"},
         {"name": "species"},
     ]
     violations = gdcdictionary.validate_instances(instances, partial)
@@ -75,12 +78,12 @@ def test_validate_instances__invalid_types(partial: bool) -> None:
     assert len(violations) > 2
 
     unknown_types = [v for v in violations if v.schema == ""]
-    assert len(unknown_types) == 2
+    assert len(unknown_types) == 1
 
     case_required_field_violation = next(
-        v for v in violations if v.schema == "case" and v.keys == ["submitter_id"]
+        v for v in violations if v.schema == "aliquot" and v.keys == ["submitter_id", "id"]
     )
-    assert case_required_field_violation.message == "'submitter_id' is a required property"
+    assert case_required_field_violation.message == "one of ['submitter_id', 'id'] is required."
 
     case_extra_field_violation = next(
         v for v in violations if v.schema == "case" and v.keys == ["python_version"]
@@ -93,6 +96,9 @@ def test_validate_instances__invalid_types(partial: bool) -> None:
 
 def test_partials_validation():
     # example missing required fields
-    instance = {"type": "case", "days_to_consent": 123, "submitter_id": "UNSC-2"}
-    violations = gdcdictionary.validate_instances(instances=[instance], partial=True)
+    instances = [
+        {"type": "case", "days_to_consent": 123, "submitter_id": "UNSC-2"},
+        {"type": "case", "days_to_consent": 123, "id": str(uuid.uuid4())},
+    ]
+    violations = gdcdictionary.validate_instances(instances, partial=True)
     assert len(violations) == 0


### PR DESCRIPTION
Update partial validators to allow one of `submitter_id` and `id` as required fields. This is enable partial submissions work by either specifying the existing node_id or the submitter_id