### PR TITLE
Turing updates to family_history node

### DIFF
--- a/src/gdcdictionary/schemas/family_history.yaml
+++ b/src/gdcdictionary/schemas/family_history.yaml
@@ -52,6 +52,32 @@ properties:
     maximum: 89
     minimum: 0
 
+  relationship_gender:
+    $ref:
+      - "_terms.yaml#/relationship_gender/common"
+    enum:
+      - female
+      - male
+      - unspecified
+      - unknown
+      - not reported
+    enumDef:
+      female:
+        $ref:
+          - "_terms_enum.yaml#/female/common"
+      male:
+        $ref:
+          - "_terms_enum.yaml#/male/common"
+      unspecified:
+        $ref:
+          - "_terms_enum.yaml#/unspecified/common"
+      unknown:
+        $ref:
+          - "_terms_enum.yaml#/unknown/common"
+      not reported:
+        $ref:
+          - "_terms_enum.yaml#/not_reported/common"
+
   relationship_primary_diagnosis:
     $ref:
       - "_terms.yaml#/relationship_primary_diagnosis/common"

--- a/src/gdcdictionary/schemas/family_history.yaml
+++ b/src/gdcdictionary/schemas/family_history.yaml
@@ -49,32 +49,6 @@ properties:
     maximum: 89
     minimum: 0
 
-  relationship_gender:
-    $ref:
-      - "_terms.yaml#/relationship_gender/common"
-    enum:
-      - female
-      - male
-      - unspecified
-      - unknown
-      - not reported
-    enumDef:
-      female:
-        $ref:
-          - "_terms_enum.yaml#/female/common"
-      male:
-        $ref:
-          - "_terms_enum.yaml#/male/common"
-      unspecified:
-        $ref:
-          - "_terms_enum.yaml#/unspecified/common"
-      unknown:
-        $ref:
-          - "_terms_enum.yaml#/unknown/common"
-      not reported:
-        $ref:
-          - "_terms_enum.yaml#/not_reported/common"
-
   relationship_primary_diagnosis:
     $ref:
       - "_terms.yaml#/relationship_primary_diagnosis/common"
@@ -288,6 +262,24 @@ properties:
       Not Reported:
         $ref:
           - "_terms_enum.yaml#/not_reported/common"
+
+  relationship_sex_at_birth:
+    $ref:
+      - "_terms.yaml#/relationship_sex_at_birth/common"
+    enum:
+      - female
+      - male
+      - unknown
+    enumDef:
+      female:
+        $ref:
+          - "_terms_enum.yaml#/female/common"
+      male:
+        $ref:
+          - "_terms_enum.yaml#/male/common"
+      unknown:
+        $ref:
+          - "_terms_enum.yaml#/unknown/common"
 
   relationship_type:
     $ref:

--- a/src/gdcdictionary/schemas/family_history.yaml
+++ b/src/gdcdictionary/schemas/family_history.yaml
@@ -37,6 +37,9 @@ uniqueKeys:
   - [id]
   - [project_id, submitter_id]
 
+deprecated:
+  - relationship_gender
+
 properties:
 
   $ref:


### PR DESCRIPTION
Turing updates to family_history node by adding relationship_sex_at_birth and deprecating relationship_gender in support of [DICT-548](https://gdc-ctds.atlassian.net/browse/DICT-548)