### PR TITLE
DEV-3574: Remove reference to gdcdatamodel2 setup.cfg

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,9 +70,9 @@ push_datamodels_to_github:
     - execute_plaster
   script:
     - cd gdcdatamodel2
-    - cat setup.cfg
     - git status
-    - git add .
+    - git add -f .
+    - git status
     - git commit -m "Use gdcdictionary $CI_COMMIT_REF_NAME $CI_COMMIT_SHA" || true
     - git rev-parse --short HEAD
     - git push origin "$CI_COMMIT_REF_NAME" || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ push_datamodels_to_github:
   script:
     - cd gdcdatamodel2
     - git status
-    - git add -f .
+    - git add .
     - git status
     - git commit -m "Use gdcdictionary $CI_COMMIT_REF_NAME $CI_COMMIT_SHA" || true
     - git rev-parse --short HEAD


### PR DESCRIPTION
Update gitlab-ci for building gdcdatamodel2:
- remove ref to `setup.cfg`
- added `git status` after `git add .` for debugging purposes.